### PR TITLE
feat: make serializer used configurable and add MsgPack option

### DIFF
--- a/caching/caching_test.go
+++ b/caching/caching_test.go
@@ -276,7 +276,7 @@ func TestBatchGetItemAllHits(t *testing.T) {
 	if err != nil {
 		t.Errorf("error serializing movie 1 map: %+v", err)
 	}
-	item2ToCache, err := ddbSerializer.Serialize(movie1Map)
+	item2ToCache, err := ddbSerializer.Serialize(movie2Map)
 	if err != nil {
 		t.Errorf("error serializing movie 2 map: %+v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/aws/smithy-go v1.21.0
 	github.com/google/uuid v1.6.0
 	github.com/momentohq/client-sdk-go v1.28.2
+	github.com/vmihailenco/msgpack/v5 v5.4.1
 )
 
 require (
@@ -29,6 +30,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.31.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,12 @@ github.com/onsi/gomega v1.26.0/go.mod h1:r+zV744Re+DiYCIPRlYOTxn0YkOLcAnW8k1xXdM
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
 golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=

--- a/internal/serializer/bench_test.go
+++ b/internal/serializer/bench_test.go
@@ -1,0 +1,155 @@
+package serializer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+type testPayload struct {
+	name string
+	item map[string]types.AttributeValue
+}
+
+var testPayloads = []testPayload{
+	{name: "SmallItem", item: smallItem},
+	{name: "LargeItem", item: largeSizeItem},
+	{name: "ComplexItem", item: complexItem},
+}
+
+type Serializer interface {
+	Name() string
+	Serialize(item map[string]types.AttributeValue) ([]byte, error)
+	Deserialize(data []byte) (map[string]types.AttributeValue, error)
+}
+
+func BenchmarkSerialization(b *testing.B) {
+	serializers := []struct {
+		name       string
+		serializer Serializer
+	}{
+		{name: "JSON", serializer: JSONSerializer{}},
+		{name: "MsgPack", serializer: MsgPackSerializer{}},
+	}
+
+	for _, serializer := range serializers {
+		for _, payload := range testPayloads {
+			b.Run(serializer.name+"Marshal/"+payload.name, func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					_, err := serializer.serializer.Serialize(payload.item)
+					if err != nil {
+						b.Error(err)
+					}
+				}
+			})
+
+			b.Run(serializer.name+"Unmarshal/"+payload.name, func(b *testing.B) {
+				data, err := serializer.serializer.Serialize(payload.item)
+				if err != nil {
+					b.Error(err)
+				}
+
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					_, err := serializer.serializer.Deserialize(data)
+					if err != nil {
+						b.Error(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+var smallItem = map[string]types.AttributeValue{
+	"info":  &types.AttributeValueMemberNULL{Value: true},
+	"title": &types.AttributeValueMemberS{Value: "A Movie Part 1"},
+	"year":  &types.AttributeValueMemberN{Value: "2022"},
+}
+
+var largeSizeItem = map[string]types.AttributeValue{
+	"ID":        &types.AttributeValueMemberN{Value: "123456"},
+	"Name":      &types.AttributeValueMemberS{Value: "Test Item"},
+	"LargeText": &types.AttributeValueMemberS{Value: strings.Repeat("a", 10_000)},
+	"Category":  &types.AttributeValueMemberS{Value: "CategoryA"},
+	"Active":    &types.AttributeValueMemberBOOL{Value: true},
+}
+
+var complexItem = map[string]types.AttributeValue{
+	"Name":    &types.AttributeValueMemberS{Value: "Test Item"},
+	"ID":      &types.AttributeValueMemberN{Value: "12345"},
+	"Active":  &types.AttributeValueMemberBOOL{Value: true},
+	"Tags":    &types.AttributeValueMemberSS{Value: []string{"tag1", "tag2", "tag3"}},
+	"Ratings": &types.AttributeValueMemberNS{Value: []string{"5", "4", "3"}},
+	"Data":    &types.AttributeValueMemberBS{Value: [][]byte{[]byte("binarydata1"), []byte("binarydata2")}},
+	"Attributes": &types.AttributeValueMemberM{
+		Value: map[string]types.AttributeValue{
+			"Height":  &types.AttributeValueMemberN{Value: "180"},
+			"Weight":  &types.AttributeValueMemberN{Value: "75"},
+			"Skills":  &types.AttributeValueMemberSS{Value: []string{"skill1", "skill2"}},
+			"Scores":  &types.AttributeValueMemberNS{Value: []string{"10", "9.5", "8"}},
+			"Active":  &types.AttributeValueMemberBOOL{Value: false},
+			"Deleted": &types.AttributeValueMemberNULL{Value: true},
+		},
+	},
+	"Items": &types.AttributeValueMemberL{
+		Value: []types.AttributeValue{
+			&types.AttributeValueMemberM{
+				Value: map[string]types.AttributeValue{
+					"ItemID":   &types.AttributeValueMemberN{Value: "101"},
+					"ItemName": &types.AttributeValueMemberS{Value: "Sub Item 1"},
+					"Price":    &types.AttributeValueMemberN{Value: "25.50"},
+					"InStock":  &types.AttributeValueMemberBOOL{Value: true},
+				},
+			},
+			&types.AttributeValueMemberM{
+				Value: map[string]types.AttributeValue{
+					"ItemID":   &types.AttributeValueMemberN{Value: "102"},
+					"ItemName": &types.AttributeValueMemberS{Value: "Sub Item 2"},
+					"Price":    &types.AttributeValueMemberN{Value: "15.75"},
+					"InStock":  &types.AttributeValueMemberBOOL{Value: false},
+				},
+			},
+			&types.AttributeValueMemberM{
+				Value: map[string]types.AttributeValue{
+					"ItemID":   &types.AttributeValueMemberN{Value: "103"},
+					"ItemName": &types.AttributeValueMemberS{Value: "Sub Item 3"},
+					"Price":    &types.AttributeValueMemberN{Value: "100.00"},
+					"InStock":  &types.AttributeValueMemberBOOL{Value: true},
+				},
+			},
+		},
+	},
+	"History": &types.AttributeValueMemberL{
+		Value: []types.AttributeValue{
+			&types.AttributeValueMemberM{
+				Value: map[string]types.AttributeValue{
+					"Action":    &types.AttributeValueMemberS{Value: "Created"},
+					"Timestamp": &types.AttributeValueMemberS{Value: "2023-01-01T12:00:00Z"},
+				},
+			},
+			&types.AttributeValueMemberM{
+				Value: map[string]types.AttributeValue{
+					"Action":    &types.AttributeValueMemberS{Value: "Updated"},
+					"Timestamp": &types.AttributeValueMemberS{Value: "2023-03-01T09:30:00Z"},
+				},
+			},
+			&types.AttributeValueMemberM{
+				Value: map[string]types.AttributeValue{
+					"Action":    &types.AttributeValueMemberS{Value: "Deleted"},
+					"Timestamp": &types.AttributeValueMemberS{Value: "2023-04-15T16:45:00Z"},
+				},
+			},
+		},
+	},
+	"RelatedItems": &types.AttributeValueMemberL{
+		Value: []types.AttributeValue{
+			&types.AttributeValueMemberSS{Value: []string{"relItem1", "relItem2"}},
+			&types.AttributeValueMemberSS{Value: []string{"relItem3"}},
+		},
+	},
+	"Notes":    &types.AttributeValueMemberNULL{Value: true},
+	"Quantity": &types.AttributeValueMemberN{Value: "50"},
+	"Discount": &types.AttributeValueMemberN{Value: "5.00"},
+}

--- a/internal/serializer/bench_test.go
+++ b/internal/serializer/bench_test.go
@@ -35,7 +35,7 @@ func BenchmarkSerialization(b *testing.B) {
 
 	for _, serializer := range serializers {
 		for _, payload := range testPayloads {
-			b.Run(serializer.name+"Marshal/"+payload.name, func(b *testing.B) {
+			b.Run(serializer.name+"Serialize/"+payload.name, func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					_, err := serializer.serializer.Serialize(payload.item)
 					if err != nil {
@@ -44,7 +44,7 @@ func BenchmarkSerialization(b *testing.B) {
 				}
 			})
 
-			b.Run(serializer.name+"Unmarshal/"+payload.name, func(b *testing.B) {
+			b.Run(serializer.name+"Deserialize/"+payload.name, func(b *testing.B) {
 				data, err := serializer.serializer.Serialize(payload.item)
 				if err != nil {
 					b.Error(err)

--- a/internal/serializer/serializer.go
+++ b/internal/serializer/serializer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/vmihailenco/msgpack/v5"

--- a/internal/serializer/serializer.go
+++ b/internal/serializer/serializer.go
@@ -1,0 +1,70 @@
+package serializer
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+type MsgPackSerializer struct{}
+
+func (d MsgPackSerializer) Name() string {
+	return "MsgPack"
+}
+
+func (d MsgPackSerializer) Serialize(item map[string]types.AttributeValue) ([]byte, error) {
+	var t map[string]interface{}
+	err := attributevalue.UnmarshalMap(item, &t)
+	if err != nil {
+		panic(err)
+	}
+	return msgpack.Marshal(t)
+}
+
+func (d MsgPackSerializer) Deserialize(data []byte) (map[string]types.AttributeValue, error) {
+	var item map[string]interface{}
+	err := msgpack.Unmarshal(data, &item)
+	if err != nil {
+		panic(err)
+	}
+	return attributevalue.MarshalMap(item)
+}
+
+type JSONSerializer struct{}
+
+func (d JSONSerializer) Name() string {
+	return "JSON"
+}
+
+func (d JSONSerializer) Serialize(item map[string]types.AttributeValue) ([]byte, error) {
+	// unmarshal raw response object to DDB attribute values map
+	var t map[string]interface{}
+	err := attributevalue.UnmarshalMap(item, &t)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding output item to store in cache err=%+v", err)
+	}
+
+	// Marshal to JSON to store in cache
+	j, err := json.Marshal(t)
+	if err != nil {
+		return nil, fmt.Errorf("error json encoding new item to store in cache err=%+v", err)
+	}
+	return j, nil
+}
+
+func (d JSONSerializer) Deserialize(data []byte) (map[string]types.AttributeValue, error) {
+	var t map[string]interface{}
+	err := json.NewDecoder(bytes.NewReader(data)).Decode(&t)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding json item in cache to return: %w", err)
+	}
+
+	marshalMap, err := attributevalue.MarshalMap(t)
+	if err != nil {
+		return nil, fmt.Errorf("error encoding item in cache to ddbItem to return: %w", err)
+	}
+	return marshalMap, nil
+}


### PR DESCRIPTION
* Makes serializers/deserializers configurable.
* Introduce a new MsgPack serializer/deserializer using github.com/vmihailenco/msgpack/v5
* Keeps serializer defaulted to json for now. Will switch it to default in another pr after some more customer testing/feedback.
* Added some bench mark tests to show performance improvements moving to MsgPack over std `encoding/json` lib (results below)

Results of bench mark tests:

Serialize Tests Small Items
```console
JSON/SmallItem                9748170              1205 ns/op             896 B/op         24 allocs/op
MsgPack/SmallItem            12910341               935.7 ns/op           720 B/op         18 allocs/op
```

Serialize Tests Large Items
```console
JSON/LargeItem                  995557             11977 ns/op           11390 B/op         37 allocs/op
MsgPack/LargeItem              4913210              2412 ns/op           11132 B/op         28 allocs/op
```

Serialize Tests Complex Items
```console
JSON/ComplexItem               648261             15673 ns/op            9365 B/op        241 allocs/op
MsgPack/ComplexItem           1000000             11584 ns/op            7905 B/op        164 allocs/op
```

Deserialize Tests Small items
```console
JSON/SmallItem              7049923              1754 ns/op            2083 B/op         39 allocs/op
MsgPack/SmallItem          11058334              1103 ns/op            1169 B/op         30 allocs/op
```


Deserialize Tests Large items
```console
JSON/LargeItem               275281             42886 ns/op           42839 B/op         59 allocs/op
MsgPack/LargeItem           4403280              2710 ns/op           11694 B/op         44 allocs/op
```


Deserialize Tests Complex items
```console
JSON/ComplexItem             542331             22036 ns/op           16173 B/op        421 allocs/op
MsgPack/ComplexItem          724035             16762 ns/op           12877 B/op        377 allocs/op
```